### PR TITLE
Allow image upload.

### DIFF
--- a/react-prosemirror-config-default/src/menuItems/helpers.js
+++ b/react-prosemirror-config-default/src/menuItems/helpers.js
@@ -30,12 +30,20 @@ export const canInsert = type => state => {
   return false
 }
 
-export const promptForURL = () => {
-  let url = window && window.prompt('Enter the URL', 'https://')
+export const promptForURL = (refs, promptName, callback) => {
+  let prompt = refs[promptName];
 
-  if (url && !/^https?:\/\//i.test(url)) {
-    url = 'https://' + url
+  if(prompt) {
+    prompt.show(callback);
+  } else {
+    let url = window && window.prompt('Enter the URL', 'https://')
+
+    if(!url) { return false; }
+
+    if (url && !/^https?:\/\//i.test(url)) {
+      url = 'https://' + url
+    }
+
+    callback(url);
   }
-
-  return url
 }

--- a/react-prosemirror-config-default/src/menuItems/inserts.js
+++ b/react-prosemirror-config-default/src/menuItems/inserts.js
@@ -44,17 +44,20 @@ const htmlSpecific = (schema) => {
 }
 
 const generic = (schema) => {
+  const addImage = (dispatch, state, src) => {
+    const img = schema.nodes.image.createAndFill({ src })
+    dispatch(state.tr.replaceSelectionWith(img))
+  };
+
   return {
     image: {
       title: 'Insert image',
       content: icons.image,
       enable: canInsert(schema.nodes.image),
-      run: (state, dispatch) => {
-        const src = promptForURL()
-        if (!src) return false
-
-        const img = schema.nodes.image.createAndFill({ src })
-        dispatch(state.tr.replaceSelectionWith(img))
+      run: (state, dispatch, refs) => {
+        promptForURL(refs, 'imagePrompt', (src) => {
+          addImage(dispatch, state, src);
+        });
       }
     },
     // hr: {

--- a/react-prosemirror-config-default/src/menuItems/marks.js
+++ b/react-prosemirror-config-default/src/menuItems/marks.js
@@ -56,16 +56,16 @@ const generic = (schema) => {
       content: icons.link,
       active: markActive(schema.marks.link),
       enable: state => !state.selection.empty,
-      run (state, dispatch) {
+      run (state, dispatch, refs) {
         if (markActive(schema.marks.link)(state)) {
           toggleMark(schema.marks.link)(state, dispatch)
           return true
         }
 
-        const href = promptForURL()
-        if (!href) return false
+        promptForURL(refs, 'linkPrompt', (href) => {
+          toggleMark(schema.marks.link, { href })(state, dispatch)
+        });
 
-        toggleMark(schema.marks.link, { href })(state, dispatch)
         // view.focus()
       }
     }

--- a/react-prosemirror-example/package.json
+++ b/react-prosemirror-example/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@aeaton/react-prosemirror": "^0.10.1",
-    "prosemirror-howdy-wip": "https://github.com/HowdyHub/react-prosemirror/tarball/github-version/react-prosemirror-config-default",
+    "prosemirror-howdy-wip": "https://github.com/HowdyHub/react-prosemirror/tarball/github-version-dev",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "^1.1.0",

--- a/react-prosemirror-example/src/index.js
+++ b/react-prosemirror-example/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import styled from 'styled-components'
-import { Editor, MenuBar } from '@aeaton/react-prosemirror'
+import { Editor, MenuBar } from 'prosemirror-howdy-wip/react-prosemirror'
 import { options, menu } from 'prosemirror-howdy-wip/react-prosemirror-config-default'
 
 const Container = styled('div')`

--- a/react-prosemirror/package.json
+++ b/react-prosemirror/package.json
@@ -18,7 +18,8 @@
     "lodash": "^4.17.4",
     "prosemirror-model": "^1.0.0",
     "prosemirror-state": "^1.1.0",
-    "prosemirror-view": "^1.0.0"
+    "prosemirror-view": "^1.0.0",
+    "react": "^16.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/react-prosemirror/src/MenuBar.js
+++ b/react-prosemirror/src/MenuBar.js
@@ -3,7 +3,9 @@ import map from 'lodash/map'
 import classnames from 'classnames'
 import classes from './MenuBar.module.css'
 
-const Button = (state, dispatch) => (item, key) => (
+import Prompt from './Prompt';
+
+const Button = (state, dispatch, refs) => (item, key) => (
   <button
     key={key}
     type="button"
@@ -15,25 +17,53 @@ const Button = (state, dispatch) => (item, key) => (
     disabled={item.enable && !item.enable(state)}
     onMouseDown={e => {
       e.preventDefault()
-      item.run(state, dispatch)
+
+      item.run(state, dispatch, refs)
     }}
   >{item.content}</button>
 )
 
-const MenuBar = ({ menu, children, state, dispatch }) => (
-  <div className={classes.bar}>
-    {children && (
-      <span className={classes.group}>
-        {children}
-      </span>
-    )}
+class MenuBar extends React.Component {
+  static defaultProps = {
+    prompts: []
+  };
 
-    {map(menu, (item, key) => (
-      <span key={key} className={classes.group}>
-        {map(item, Button(state, dispatch))}
-      </span>
-    ))}
-  </div>
-)
+  renderPrompt(prompt, key) {
+    let promptProps = prompt.props || {},
+        PromptComponent = prompt.component || Prompt,
+        promptVisible = this.refs[prompt.reference] ? this.refs[prompt.reference].state.show : false;
+
+    return (
+      <div key={key} className={classnames({
+        'prompt': true,
+        'active': promptVisible
+      })}>
+        <PromptComponent ref={prompt.reference} {...promptProps} />
+      </div>
+    );
+  }
+
+  render() {
+    let { menu, children, state, dispatch, prompts } = this.props;
+
+    return (
+      <div className={classes.bar}>
+        {children && (
+          <span className={classes.group}>
+            {children}
+          </span>
+        )}
+
+        {map(menu, (item, key) => (
+          <span key={key} className={classes.group}>
+            {map(item, Button(state, dispatch, this.refs))}
+          </span>
+        ))}
+
+        {prompts.map(this.renderPrompt.bind(this))}
+      </div>
+    )
+  }
+}
 
 export default MenuBar

--- a/react-prosemirror/src/Prompt.css
+++ b/react-prosemirror/src/Prompt.css
@@ -1,0 +1,36 @@
+.prompt > div {
+  display: flex;
+  flex-wrap: wrap;
+  position: absolute;
+  top: 10px; right: 10px; left: 10px;
+  padding: 10px 10px;
+  background: #fff; border: 1px solid #ddd;
+  z-index: 1;
+}
+
+.prompt > div input {
+  width: 85%;
+  margin-right: 15px;
+}
+
+.prompt > div button {
+  align-self: flex-end;
+}
+
+.prompt > div .close-prompt {
+  position: absolute;
+  right: 10px;
+}
+
+.prompt > div .error-message {
+  display: block;
+  color: red;
+}
+
+.prompt.active::before {
+  position: absolute;
+  top: 0; right: 0; bottom: 0; left: 0;
+  background: rgba(238, 238, 238, 0.5);
+  content: '';
+  z-index: 1;
+}

--- a/react-prosemirror/src/Prompt.js
+++ b/react-prosemirror/src/Prompt.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import './Prompt.css'
+
+export default class Prompt extends React.Component {
+  static defaultProps = {
+    input: {
+      name: 'linkUrl',
+      className: 'input'
+    },
+    button: {
+      className: 'button',
+      copy: 'Add'
+    }
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = { show: false }
+  }
+
+  show(onValueAdded) {
+    this.onValueAdded = onValueAdded
+    this.setState({ show: true })
+  }
+
+  hide(ev = null) {
+    if(ev) { ev.preventDefault(); }
+    this.setState({ show: false })
+  }
+
+  useValue(ev) {
+    ev.preventDefault();
+
+    let input = ev.currentTarget.parentElement.querySelector('input');
+    if(input.checkValidity()) {
+      this.onValueAdded(input.value);
+      this.hide();
+    } else {
+      this.refs.error.classList.add('error-message');
+      this.refs.error.innerText = input.validationMessage;
+    }
+  }
+
+  render() {
+    if(!this.state.show) { return null; }
+
+    const inputProps = this.props.input,
+      buttonProps = this.props.button;
+
+    return (
+      <div>
+        <a href="#" onClick={this.hide.bind(this)} className="close-prompt">X</a>
+        <span ref="error" />
+        <input type="url" required name={inputProps.name} className={inputProps.className} pattern="^(https){1}:\/\/.+$"/>
+        <button type="button" onClick={this.useValue.bind(this)} className={buttonProps.className}>{buttonProps.copy}</button>
+      </div>
+    )
+  }
+}

--- a/react-prosemirror/src/index.js
+++ b/react-prosemirror/src/index.js
@@ -1,3 +1,4 @@
 export { default as Editor } from './Editor'
 export { default as HtmlEditor } from './HtmlEditor'
 export { default as MenuBar } from './MenuBar'
+export { default as Prompt } from './Prompt'


### PR DESCRIPTION
In order to implement image upload (and allow client apps to define their own upload option and prompt layout), changes were required in multiple places of the code.

To start with, the wrapper had to have a way to understand when custom prompts are used and when to use default Prompt component (window.prompt is kept as a fallback).
Then, when one of the buttons that use new Prompt ('add link' and 'insert image') the function opening the prompt has a way of getting the URL back from the prompts.
This is done using simplest way - a callback which calls whatever was called in the previous implementation.

Prompt styles are easily accessible from the client stylesheets.

In order to use custom prompts a `prompts=[ {}, {} ]` prop on MenuBar is used.
To display default Prompt provided by the react-prosemirror just pass `{ reference: 'promptReference' }` as the element of 'prompts' prop. Where 'promptReference' is one of 'linkPrompt' or 'imagePrompt'.
To display custom prompt component pass `{ reference: 'promptReference', component: PromptComponent }` (add `props: {}` if PromptComponent requries any additional ones).